### PR TITLE
Fix a typo in .NET example

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -5,7 +5,7 @@ Create a new console app:
 
 ```sh
 dotnet new console -o myApp
-dotnet build
+cd myApp
 ```
 
 Publish as a [self-contained](https://docs.microsoft.com/en-us/dotnet/core/deploying/runtime-patch-selection) app:


### PR DESCRIPTION
Change directory was missing. and we don't need to explicitly call build, publish does that for us.