### PR TITLE
Set explicit GOARCH

### DIFF
--- a/golang/01-hello-world/README.md
+++ b/golang/01-hello-world/README.md
@@ -9,7 +9,7 @@ using linux, the compilation should be the same.
  1. Build our golang application.
 
 ```sh
-$ GOOS=linux go build hello.go
+$ GOOS=linux GOARCH=amd64 go build hello.go
 ```
 
  2. Run our application within `ops`

--- a/golang/02-hello-world-config/README.md
+++ b/golang/02-hello-world-config/README.md
@@ -9,7 +9,7 @@ using linux, the compilation should be the same.
  1. Build our golang application.
 
 ```sh
-$ GOOS=linux go build hello.go
+$ GOOS=linux GOARCH=amd64 go build hello.go
 ```
 
  2. Run our application within `ops`

--- a/golang/03-http-hello-world/README.md
+++ b/golang/03-http-hello-world/README.md
@@ -5,13 +5,13 @@ Golang HTTP Hello World
 
 on mac:
 ```sh
-$ GOOS=linux go build 
+$ GOOS=linux GOARCH=amd64 go build
 ```
 
 on linux:
 
 ```sh
-$ go build 
+$ go build
 ```
 
  2. Run our application within `ops`

--- a/golang/04-https-hello-world/README.md
+++ b/golang/04-https-hello-world/README.md
@@ -5,11 +5,11 @@ Ensure to have your server private key && cert.
 
 on mac:
 ```sh
-$ GOOS=linux go build 
+$ GOOS=linux GOARCH=amd64 go build
 ```
 
 on linux:
 
 ```sh
-$ go build 
+$ go build
 ```

--- a/golang/05-empty-volume/README.md
+++ b/golang/05-empty-volume/README.md
@@ -3,7 +3,7 @@ Go Read-Write Mounted Volume
 
 1. build our Go application
 ```sh
-$ GOOS=linux go build -o volume-example
+$ GOOS=linux GOARCH=amd64 go build -o volume-example
 ```
 
 2. create empty volume using `ops volume create <volume_name>`
@@ -13,7 +13,7 @@ ops volume create empty
 
 3. get list of created volumes to find the UUID of relevant volume to attach
 ```sh
-ops volume list 
+ops volume list
 
 NAME		UUID		PATH
 empty		some-uuid	path-to-volume

--- a/golang/06-non-empty-volume/README.md
+++ b/golang/06-non-empty-volume/README.md
@@ -3,7 +3,7 @@ Go Read-Write Mounted Volume
 
 1. build our Go application
 ```sh
-$ GOOS=linux go build -o volume-example
+$ GOOS=linux GOARCH=amd64 go build -o volume-example
 ```
 
 2. create volume using `ops volume create <volume_name> -d <path_to_data_source>`
@@ -13,7 +13,7 @@ ops volume create not-empty -d files/
 
 3. get list of created volumes to find the UUID of relevant volume to attach
 ```sh
-ops volume list 
+ops volume list
 
 NAME		UUID		PATH
 not-empty	some-uuid	path-to-volume

--- a/golang/README.md
+++ b/golang/README.md
@@ -6,5 +6,5 @@ the OS of `ops` rather than your machine's OS. So always make sure you are
 building for linux.
 
 ```sh
-$ GOOS=linux go build
+$ GOOS=linux GOARCH=amd64 go build
 ```


### PR DESCRIPTION
Building on M1 macs:
```
GOOS=linux go build hello.go
```
will result in:
```
signal 11 received by tid 2, errno 0, code 1
   fault address 0x0
```
Set explicit GOARCH to avoid