### PR TITLE
Fixing command for start by adding repostory prefix and updating node version

### DIFF
--- a/javascript/01-hello-world/README.md
+++ b/javascript/01-hello-world/README.md
@@ -2,5 +2,5 @@ NodeJS Hello World
 ==================
 
 ```sh
-$ ops pkg load node_v14.2.0 -a ex.js
+$ ops pkg load eyberg/node:20.5.0 -a ex.js
 ```


### PR DESCRIPTION
The start command did not work because the package name is missing a prefix and the node version is older.